### PR TITLE
Python code style setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[pycodestyle]
+ignore = E121, E126, E402, W504
+max-line-length = 100


### PR DESCRIPTION
This setup file is used by Python linters and docstyle checkers.